### PR TITLE
Fix DNS Stability and Network Changes

### DIFF
--- a/core/src/dns_handler.h
+++ b/core/src/dns_handler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -256,8 +257,12 @@ private:
     std::unordered_map<uint16_t, uint64_t> m_upstream_conn_id_by_system_client_id;
     std::unordered_map<uint16_t, uint64_t> m_upstream_conn_id_by_system_client_ipv6_id;
 
+    size_t m_user_dns_failure_count = 0;
+    std::chrono::steady_clock::time_point m_last_user_dns_restart{};
+
     bool start_dns_proxy();
     bool start_system_dns_proxy();
+    void handle_user_dns_proxy_failure();
 
     static void client_handler(void *arg, DnsClientEvent what, void *data);
     static void system_client_handler(void *arg, DnsClientEvent what, void *data);


### PR DESCRIPTION
# Fix DNS Stability and Network Changes

## Description
This PR addresses DNS timeout issues and improves stability when network changes occur.
Specifically, it restarts the user DNS proxy upon network failures or switches to prevent the VPN from effectively blocking connectivity due to stale DNS configurations.

## Changes
- `core/src/dns_handler.cpp`: Logic to restart DNS proxy on network change.

## Justification
"why it is needed?".

I observed DNS timeouts during testing. The fix ensures that the DNS proxy doesn't get stuck in a bad state when the underlying network switches (e.g., WiFi to Data).

## How to test
1. Connect VPN.
2. Toggle between WiFi and Mobile Data.
3. Verify DNS resolution continues to work without timeouts.
