### PR TITLE
Support hot reload of exclusions via SIGUSR1

### DIFF
--- a/trusttunnel/include/vpn/trusttunnel/client.h
+++ b/trusttunnel/include/vpn/trusttunnel/client.h
@@ -87,6 +87,8 @@ public:
 
     bool process_client_packets(VpnPackets packets);
 
+    void reload_exclusions(const std::string &config_path);
+
     std::string_view get_bound_if() const;
 
     ~TrustTunnelClient();

--- a/trusttunnel/src/client.cpp
+++ b/trusttunnel/src/client.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include <magic_enum/magic_enum.hpp>
+#include <toml++/toml.h>
 
 #include "common/logger.h"
 #include "common/net_utils.h"
@@ -56,6 +57,30 @@ void TrustTunnelClient::notify_network_change(VpnNetworkState state) {
     if (m_vpn) {
         vpn_notify_network_change(m_vpn, state);
     }
+}
+
+void TrustTunnelClient::reload_exclusions(const std::string &config_path) {
+    infolog(m_logger, "Reloading exclusions from '{}'", config_path);
+
+    toml::parse_result parse_result = toml::parse_file(config_path);
+    if (!parse_result) {
+        errlog(m_logger, "Failed to reload config: {}", parse_result.error().description());
+        return;
+    }
+
+    std::string exclusions;
+    if (const auto *x = parse_result["exclusions"].as_array(); x != nullptr) {
+        for (const auto &e : *x) {
+            if (std::optional ex = e.value<std::string_view>(); ex.has_value() && !ex->empty()) {
+                exclusions.append(ex.value());
+                exclusions.push_back(' ');
+            }
+        }
+    }
+
+    m_config.exclusions = exclusions;
+    vpn_update_exclusions(m_vpn, m_config.mode, {exclusions.data(), (uint32_t) exclusions.size()});
+    infolog(m_logger, "Exclusions reloaded successfully");
 }
 
 void TrustTunnelClient::notify_sleep() {

--- a/trusttunnel/src/trusttunnel_client.cpp
+++ b/trusttunnel/src/trusttunnel_client.cpp
@@ -37,6 +37,7 @@ static std::atomic_bool keep_running{true};
 static std::condition_variable g_waiter;
 static std::mutex g_waiter_mutex;
 static std::weak_ptr<TrustTunnelClient> g_client;
+static std::string g_config_path;
 
 static std::function<void(SocketProtectEvent *)> get_protect_socket_callback(const TrustTunnelConfig &config);
 static std::function<void(VpnVerifyCertificateEvent *)> get_verify_certificate_callback();
@@ -63,6 +64,13 @@ static void sighandler(int sig) {
             t.detach();
             return;
         }
+        if (sig == SIGUSR1) {
+            std::thread t([client]() {
+                client->reload_exclusions(g_config_path);
+            });
+            t.detach();
+            return;
+        }
 #endif
         stop_trusttunnel_client();
     } else {
@@ -82,6 +90,7 @@ static void setup_sighandler() {
     sigaddset(&sigset, SIGINT);
     sigaddset(&sigset, SIGTERM);
     sigaddset(&sigset, SIGHUP);
+    sigaddset(&sigset, SIGUSR1);
     pthread_sigmask(SIG_BLOCK, &sigset, nullptr);
     std::thread([sigset] {
         int signum = 0;
@@ -117,7 +126,8 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    toml::parse_result parse_result = toml::parse_file(result["config"].as<std::string>());
+    g_config_path = result["config"].as<std::string>();
+    toml::parse_result parse_result = toml::parse_file(g_config_path);
     if (!parse_result) {
         errlog(g_logger, "Failed parsing configuration: {}", parse_result.error().description());
         return 1;


### PR DESCRIPTION
## Summary

Add the ability to reload the exclusions list at runtime without restarting the TrustTunnelClient process.

## Changes

- Added `reload_exclusions(config_path)` method to `TrustTunnelClient` that re-parses the TOML config file and applies updated exclusions via `vpn_update_exclusions()`
- Added `SIGUSR1` signal handling: on receiving the signal, the client reloads exclusions from the original config path in a detached thread
- Config path is now stored in `g_config_path` global for use by the signal handler

## Usage

To reload exclusions after editing the config file:

kill -USR1 <pid>
