### PR TITLE
fix(macos): fix DIRECT_UPSTREAM UDP failures on macOS

### DIFF
--- a/net/src/udp_socket.cpp
+++ b/net/src/udp_socket.cpp
@@ -125,8 +125,18 @@ static UdpSocket *udp_socket_create_inner(const UdpSocketParameters *parameters,
 
         if (0 != connect(fd, peer->c_sockaddr(), peer->c_socklen())) {
             int err = evutil_socket_geterror(fd);
-            log_sock(sock, err, "Failed to set socket destination: {} ({})", evutil_socket_error_to_string(err), err);
-            goto fail;
+#ifdef __MACH__
+            // On macOS, connect() on a UDP socket with destination port 0 returns EADDRNOTAVAIL (49).
+            // This is a kernel restriction absent on Linux. Skip connecting in this case — the socket
+            // is already bound to the physical interface via IP_BOUND_IF, and sendto() will handle addressing.
+            if (err == EADDRNOTAVAIL && peer->port() == 0) {
+                // continue without connecting
+            } else
+#endif // __MACH__
+            {
+                log_sock(sock, err, "Failed to set socket destination: {} ({})", evutil_socket_error_to_string(err), err);
+                goto fail;
+            }
         }
 
         if (0 != evutil_make_socket_nonblocking(fd)) {

--- a/trusttunnel/src/trusttunnel_client.cpp
+++ b/trusttunnel/src/trusttunnel_client.cpp
@@ -26,6 +26,7 @@
 
 #ifdef __APPLE__
 #include "AppleSleepNotifier.h"
+#include <net/if.h>
 #endif
 
 static constexpr std::string_view DEFAULT_CONFIG_FILE = "trusttunnel_client.toml";
@@ -199,7 +200,12 @@ std::function<void(SocketProtectEvent *)> get_protect_socket_callback(const Trus
 
     return [bound_if = tun->bound_if](SocketProtectEvent *event) {
 #ifdef __APPLE__
-        uint32_t idx = vpn_network_manager_get_outbound_interface();
+        uint32_t idx;
+        if (!bound_if.empty()) {
+            idx = if_nametoindex(bound_if.c_str());
+        } else {
+            idx = vpn_network_manager_get_outbound_interface();
+        }
         if (idx == 0) {
             return;
         }


### PR DESCRIPTION
## Problem

Two related issues caused all `DIRECT_UPSTREAM` UDP connections to fail on macOS when running in TUN mode with `included_routes = ["0.0.0.0/0"]`, especially when other VPN/tunnel interfaces are active (e.g. Tailscale).

### Issue 1 — `udp_socket_create_inner`: `connect()` to port 0 fails on macOS

On macOS, `connect()` on a UDP socket with destination port 0 returns `EADDRNOTAVAIL (49)` — an xnu kernel restriction that is absent on Linux. This caused a flood of errors:

```
ERROR UDP_SOCKET udp_socket_create_inner: Failed to set socket destination: Can't assign requested address (49)
ERROR DIRECT_UPSTREAM open_udp_connection: Failed to create socket
```

**Fix:** skip `connect()` when `err == EADDRNOTAVAIL && peer->port() == 0`. The socket is already bound to the physical interface via `IP_BOUND_IF` set in the protect handler, and `sendto()` handles addressing.

### Issue 2 — `get_protect_socket_callback`: `bound_if` config value ignored on macOS

The `bound_if` config value was captured in the lambda but never used on macOS — only `vpn_network_manager_get_outbound_interface()` (auto-detection) was used. When Tailscale or another tunnel interface is active alongside TrustTunnel, the auto-detected outbound interface could resolve to a VPN interface (e.g. `utun5`) rather than the physical one (e.g. `en0`), causing `connect()` to fail with `EADDRNOTAVAIL`.

**Fix:** use `bound_if` exclusively when set (via `if_nametoindex()`), with auto-detection as fallback otherwise.

## Observed symptoms

The issue was discovered while playing Dota 2 on macOS — the game uses Valve's game server network (IP ranges `155.133.x.x`, `162.254.x.x`, `146.66.x.x`, `173.237.x.x`) which communicates over UDP. The TUN intercepted this traffic and attempted direct upstream connections, all of which failed. In-game ping was broken (no relay connection could be established), and the log was flooded with errors like:

```
ERROR [1514535] UDP_SOCKET udp_socket_create_inner: [] [id=246/155.133.248.41:0] Failed to set socket destination: Can't assign requested address (49)
ERROR [1514535] DIRECT_UPSTREAM open_udp_connection: [2] Failed to create socket
ERROR [1514535] UDP_SOCKET udp_socket_create_inner: [] [id=248/146.66.155.69:0] Failed to set socket destination: Can't assign requested address (49)
ERROR [1514535] DIRECT_UPSTREAM open_udp_connection: [2] Failed to create socket
ERROR [1514535] UDP_SOCKET udp_socket_create_inner: [] [id=250/162.254.198.156:0] Failed to set socket destination: Can't assign requested address (49)
ERROR [1514535] DIRECT_UPSTREAM open_udp_connection: [2] Failed to create socket
```

## Testing

Verified on macOS with:
- `bound_if = "en0"` in config
- `included_routes = ["0.0.0.0/0"]` (full TUN mode)
- Tailscale active simultaneously
- Dota 2 running (Valve game server traffic as the trigger)

After the fix, `DIRECT_UPSTREAM` UDP connections succeed and the error flood is gone.