### PR TITLE
Optimize HTTP/2 upstream backpressure

### DIFF
--- a/common/src/event_loop.cpp
+++ b/common/src/event_loop.cpp
@@ -134,7 +134,7 @@ static const struct EventLoopStaticInitializer {
 } ENSURE_INITIALIZED [[maybe_unused]];
 
 VpnEventLoop *vpn_event_loop_create() {
-    std::unique_ptr<VpnEventLoop> loop{new VpnEventLoop{}};
+    auto loop = std::make_unique<VpnEventLoop>();
     if (loop->ev_base == nullptr) {
         log_loop(loop, err, "Failed to create event base");
         return nullptr;

--- a/core/src/http2_upstream.cpp
+++ b/core/src/http2_upstream.cpp
@@ -705,9 +705,15 @@ ssize_t Http2Upstream::send(uint64_t id, const uint8_t *data, size_t length) {
     if (auto i = m_tcp_connections.find(id); i != m_tcp_connections.end()) {
         TcpConnection *conn = &i->second;
         if (!conn->flags.test(TcpConnection::TCF_STREAM_CLOSED)) {
-            r = http_session_send_data(m_session.get(), (int32_t) conn->stream_id, data, length, false);
+            size_t available = available_to_send(id);
+            if (available == 0) {
+                return 0;
+            }
+
+            size_t to_send = std::min(length, available);
+            r = http_session_send_data(m_session.get(), (int32_t) conn->stream_id, data, to_send, false);
             if (r == 0) {
-                r = (ssize_t) length;
+                r = (ssize_t) to_send;
             } else if (r == NGHTTP2_ERR_BUFFER_ERROR) {
                 r = 0;
             }

--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -115,6 +115,7 @@ target_link_libraries(ja4 openssl::openssl fmt::fmt)
 link_libraries(ja4)
 
 add_unit_test(test_http_headers "${TEST_DIR}" "" FALSE FALSE)
+add_unit_test(test_http2 "${TEST_DIR}" "" FALSE FALSE)
 add_unit_test(test_tls_parse "${TEST_DIR}" "" FALSE FALSE)
 add_unit_test(test_ping_offline "${TEST_DIR}" "${TEST_EXTRA_INCLUDES}" TRUE TRUE)
 add_live_test(test_ping "${TEST_DIR}" "${TEST_EXTRA_INCLUDES}" TRUE TRUE)

--- a/net/src/http2.cpp
+++ b/net/src/http2.cpp
@@ -831,6 +831,10 @@ static int data_source_add(HttpStream *stream, const uint8_t *data, size_t len, 
         stream->data_source = source;
     }
     source->has_eof |= eof;
+    size_t pending = evbuffer_get_length(source->buf);
+    if (pending > DATA_QUEUE_SIZE || len > DATA_QUEUE_SIZE - pending) {
+        return NGHTTP2_ERR_BUFFER_ERROR;
+    }
     int rv = evbuffer_add(source->buf, data, len);
     return rv;
 }
@@ -875,12 +879,22 @@ static void stream_destroy(HttpStream *stream) {
 }
 
 size_t http_session_available_to_write(HttpSession *session, int32_t stream_id) {
-    int32_t r;
+    int32_t r = nghttp2_session_get_remote_window_size(session->h2->ngsession);
 
     if (stream_id != 0) {
-        r = nghttp2_session_get_stream_remote_window_size(session->h2->ngsession, stream_id);
-    } else {
-        r = nghttp2_session_get_remote_window_size(session->h2->ngsession);
+        r = std::min(r, nghttp2_session_get_stream_remote_window_size(session->h2->ngsession, stream_id));
+
+        khiter_t iter = kh_get(h2_streams_ht, session->h2->streams, (khint32_t) stream_id);
+        if (iter == kh_end(session->h2->streams)) {
+            return 0;
+        }
+
+        auto *source = (DataSource *) kh_value(session->h2->streams, iter)->data_source;
+        if (source != nullptr) {
+            size_t pending = evbuffer_get_length(source->buf);
+            size_t queue_available = pending < DATA_QUEUE_SIZE ? DATA_QUEUE_SIZE - pending : 0;
+            return std::min((r > 0) ? (size_t) r : 0, queue_available);
+        }
     }
 
     return (r > 0) ? r : 0;

--- a/net/src/os_tunnel.cpp
+++ b/net/src/os_tunnel.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <vector>
 
 #include "common/utils.h"
@@ -256,13 +257,13 @@ void ag::vpn_win_tunnel_settings_destroy(ag::VpnWinTunnelSettings *settings) {
 
 std::unique_ptr<ag::VpnOsTunnel> ag::make_vpn_tunnel() {
 #ifdef _WIN32
-    std::unique_ptr<ag::VpnWinTunnel> tunnel{new ag::VpnWinTunnel{}};
+    auto tunnel = std::make_unique<ag::VpnWinTunnel>();
     return tunnel;
 #elif __APPLE__ && !TARGET_OS_IPHONE
-    std::unique_ptr<ag::VpnMacTunnel> tunnel{new ag::VpnMacTunnel{}};
+    auto tunnel = std::make_unique<ag::VpnMacTunnel>();
     return tunnel;
 #elif __linux__ && !ANDROID
-    std::unique_ptr<ag::VpnLinuxTunnel> tunnel{new ag::VpnLinuxTunnel{}};
+    auto tunnel = std::make_unique<ag::VpnLinuxTunnel>();
     return tunnel;
 #else
     return nullptr;

--- a/net/src/tcp_socket.cpp
+++ b/net/src/tcp_socket.cpp
@@ -39,7 +39,8 @@ static Logger g_logger{"TCP_SOCKET"};
 #define LOG_ID_PREADDR_FMT "id=%d/"
 
 static constexpr size_t LOG_ID_PREFIX_SIZE = 11;
-static constexpr size_t MAX_WRITE_BUFFER_LEN = 128 * 1024;
+static constexpr size_t MAX_WRITE_QUEUE_LEN = 4 * 1024 * 1024;
+static constexpr size_t MAX_SINGLE_WRITE_LEN = 256 * 1024;
 static constexpr size_t MAX_READ_SIZE = 128 * 1024;
 
 static constexpr size_t SSL_READ_SIZE = 4096;
@@ -280,7 +281,7 @@ VpnError tcp_socket_write(TcpSocket *socket, const uint8_t *data, size_t length)
 
 size_t tcp_socket_available_to_write(const TcpSocket *socket) {
     size_t write_queue_size = evbuffer_get_length(bufferevent_get_output(socket->bev));
-    return (write_queue_size <= MAX_WRITE_BUFFER_LEN) ? MAX_WRITE_BUFFER_LEN - write_queue_size : 0;
+    return (write_queue_size <= MAX_WRITE_QUEUE_LEN) ? MAX_WRITE_QUEUE_LEN - write_queue_size : 0;
 }
 
 static void on_read(struct bufferevent *bev, void *ctx) {
@@ -445,7 +446,7 @@ static void on_connect_event(struct bufferevent *, short what, TcpSocket *ctx) {
 
         evbuffer_set_max_read(bufferevent_get_input(socket->bev), MAX_READ_SIZE);
         bufferevent_set_max_single_read(socket->bev, MAX_READ_SIZE);
-        bufferevent_set_max_single_write(socket->bev, MAX_WRITE_BUFFER_LEN);
+        bufferevent_set_max_single_write(socket->bev, MAX_SINGLE_WRITE_LEN);
 
 #ifdef _WIN32
         if (socket->parameters.record_estats) {

--- a/net/test/test_http2.cpp
+++ b/net/test/test_http2.cpp
@@ -1,0 +1,116 @@
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "net/http_header.h"
+#include "net/http_session.h"
+
+using namespace ag;
+
+struct HandlerState {
+    size_t output_bytes = 0;
+    size_t sent_bytes = 0;
+};
+
+static void require(bool condition, int line) {
+    if (!condition) {
+        (void) std::fprintf(stderr, "test_http2 failed at line %d\n", line);
+        std::abort();
+    }
+}
+
+#define REQUIRE(condition) require((condition), __LINE__)
+
+static void send_settings(HttpSession *session) {
+    static constexpr std::array<uint8_t, 9> frame = {
+            0x00,
+            0x00,
+            0x00,
+            0x04,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+    };
+    REQUIRE(http_session_input(session, frame.data(), frame.size()) == (int) frame.size());
+}
+
+static void http_handler(void *arg, HttpEventId what, void *data) {
+    auto *state = (HandlerState *) arg;
+
+    switch (what) {
+    case HTTP_EVENT_OUTPUT: {
+        const auto *event = (HttpOutputEvent *) data;
+        state->output_bytes += event->length;
+        break;
+    }
+    case HTTP_EVENT_DATA_SENT: {
+        const auto *event = (HttpDataSentEvent *) data;
+        state->sent_bytes += event->length;
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+static void send_window_update(HttpSession *session, uint32_t stream_id, uint32_t increment) {
+    std::array<uint8_t, 13> frame = {
+            0x00,
+            0x00,
+            0x04,
+            0x08,
+            0x00,
+            uint8_t((stream_id >> 24) & 0x7f),
+            uint8_t((stream_id >> 16) & 0xff),
+            uint8_t((stream_id >> 8) & 0xff),
+            uint8_t(stream_id & 0xff),
+            uint8_t((increment >> 24) & 0x7f),
+            uint8_t((increment >> 16) & 0xff),
+            uint8_t((increment >> 8) & 0xff),
+            uint8_t(increment & 0xff),
+    };
+    REQUIRE(http_session_input(session, frame.data(), frame.size()) == (int) frame.size());
+}
+
+int main() { // NOLINT(bugprone-exception-escape)
+    HandlerState state;
+    HttpSessionParams params = {
+            .id = 1,
+            .handler = {http_handler, &state},
+            .stream_window_size = 128 * 1024,
+            .version = HTTP_VER_2_0,
+    };
+
+    HttpSession *session = http_session_open(&params);
+    REQUIRE(session != nullptr);
+
+    REQUIRE(http_session_send_settings(session) == 0);
+    send_settings(session);
+
+    HttpHeaders headers{.version = HTTP_VER_2_0};
+    headers.method = "CONNECT";
+    headers.authority = "example.org:443";
+    REQUIRE(http_session_send_headers(session, 1, &headers, false) == 0);
+
+    size_t available = http_session_available_to_write(session, 1);
+    REQUIRE(available > 0);
+
+    std::vector<uint8_t> body(available, 0x42);
+    REQUIRE(http_session_send_data(session, 1, body.data(), body.size(), false) == 0);
+    REQUIRE(state.output_bytes > 0);
+    REQUIRE(state.sent_bytes == available);
+    REQUIRE(http_session_available_to_write(session, 1) == 0);
+
+    send_window_update(session, 1, (uint32_t) available);
+    REQUIRE(http_session_available_to_write(session, 1) == 0);
+
+    send_window_update(session, 0, (uint32_t) available);
+    REQUIRE(http_session_available_to_write(session, 1) == available);
+
+    REQUIRE(http_session_close(session) == 0);
+}

--- a/tcpip/test/test_vpn_packet_pool.cpp
+++ b/tcpip/test/test_vpn_packet_pool.cpp
@@ -1,12 +1,14 @@
 #include <gtest/gtest.h>
 
+#include <memory>
+
 #include "vpn_packet_pool.h"
 
 using namespace ag;
 
 TEST(VpnPacketPool, Functional) {
     constexpr size_t pool_capacity = 20;
-    std::unique_ptr<VpnPacketPool> pool{new VpnPacketPool(pool_capacity, DEFAULT_MTU_SIZE)};
+    auto pool = std::make_unique<VpnPacketPool>(pool_capacity, DEFAULT_MTU_SIZE);
     std::vector<VpnPacket> packets;
     VpnPacket packet = pool->get_packet();
 


### PR DESCRIPTION
## Related Issue

<!-- Every non-trivial PR must reference an existing issue. -->

## Summary

Make HTTP/2 upstream back-pressure honor all three relevant limits — peer
session window, peer stream window, and local data-source queue capacity — so
callers stop over-committing bytes. Also split the TCP socket's single 128 KiB
constant into a 4 MiB queue threshold and a 256 KiB per-write cap to avoid
starving the upper layer on fast links.

## Changes

- `core/src/http2_upstream.cpp`: `Http2Upstream::send()` clamps `length` to
`available_to_send(id)` and returns the actual bytes accepted instead of
unconditionally reporting `length`.
- `net/src/http2.cpp`:
  - `http_session_available_to_write()` returns `min(session_window,
stream_window, DATA_QUEUE_SIZE − pending)` for non-zero stream IDs.
  - `data_source_add()` rejects writes that would overflow `DATA_QUEUE_SIZE`
with `NGHTTP2_ERR_BUFFER_ERROR` before touching the evbuffer.
- `net/src/tcp_socket.cpp`: Replace `MAX_WRITE_BUFFER_LEN` with
`MAX_WRITE_QUEUE_LEN` (4 MiB, used by `tcp_socket_available_to_write`) and
`MAX_SINGLE_WRITE_LEN` (256 KiB, passed to
`bufferevent_set_max_single_write`).
- `net/test/test_http2.cpp` (+ `net/CMakeLists.txt`): New unit test covering
both stream-window and session-window back-pressure transitions.
- `common/src/event_loop.cpp`, `net/src/os_tunnel.cpp`,
`tcpip/test/test_vpn_packet_pool.cpp`: Replace `std::unique_ptr<T>{new T{}}`
with `std::make_unique<T>()`.

## Tests

- [x] New or updated tests cover the changes (`net/test/test_http2.cpp`
exercises stream-window exhaustion, queue-cap exhaustion, and recovery via
`WINDOW_UPDATE` on both the stream and the connection)
- [ ] All existing tests pass (`make test`)
- [ ] Benchmarks updated — comment `/bench` on this PR to dispatch the
endpoint-bench workflow (`.github/workflows/bench.yml`), then paste the
results into the **Benchmarks** section below

## Benchmarks

Need to run `/bench` command. Skip for now.

| Scenario                          | master | this PR | Δ |
|-----------------------------------|-------:|--------:|--:|
| HTTP/2 upstream throughput (1 stream, high BDP)  |        |         |   |
| HTTP/2 upstream throughput (N streams)           |        |         |   |
| TCP write latency (p50 / p99)                    |        |         |   |

<!-- Expected direction: higher throughput on fast links (4 MiB queue lifts
the per-socket buffer ceiling); back-pressure now bounded by the tightest of
the three windows, so no regression on slow links / small-window peers. -->

## Checklist

- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-visible change)
- [x] No secrets or credentials committed