### PR TITLE
feat(android): implement split tunneling (per-app proxy) support

### DIFF
--- a/platform/android/lib/src/main/java/com/adguard/trusttunnel/VpnService.kt
+++ b/platform/android/lib/src/main/java/com/adguard/trusttunnel/VpnService.kt
@@ -249,7 +249,34 @@ class VpnService : android.net.VpnService(), VpnClientListener {
                 .setMtu(tunConfig.mtuSize.toInt())
                 .addAddress("172.20.2.13", 32)
                 .addAddress("fdfd:29::2", 64)
-                .addDisallowedApplication(applicationContext.packageName)
+
+            val selfPackageName = applicationContext.packageName
+            if (tunConfig.perAppProxy) {
+                if (tunConfig.bypassApps) {
+                    builder.addDisallowedApplication(selfPackageName)
+                    tunConfig.proxyApps.forEach { pkg ->
+                        if (pkg != selfPackageName) {
+                            try {
+                                builder.addDisallowedApplication(pkg)
+                            } catch (e: Exception) {
+                                LOG.warn("Failed to bypass app $pkg: $e")
+                            }
+                        }
+                    }
+                } else {
+                    tunConfig.proxyApps.forEach { pkg ->
+                        if (pkg != selfPackageName) {
+                            try {
+                                builder.addAllowedApplication(pkg)
+                            } catch (e: Exception) {
+                                LOG.warn("Failed to proxy app $pkg: $e")
+                            }
+                        }
+                    }
+                }
+            } else {
+                builder.addDisallowedApplication(selfPackageName)
+            }
             val dnsServers = if (config.endpoint.dnsUpstreams.isEmpty()) {
                 ADGUARD_DNS_SERVERS
             } else {

--- a/platform/android/lib/src/main/java/com/adguard/trusttunnel/VpnServiceConfig.kt
+++ b/platform/android/lib/src/main/java/com/adguard/trusttunnel/VpnServiceConfig.kt
@@ -13,7 +13,13 @@ class Tun (
     @SerialName("excluded_routes")
     val excludedRoutes: List<String>,
     @SerialName("mtu_size")
-    val mtuSize: Long
+    val mtuSize: Long,
+    @SerialName("per_app_proxy")
+    val perAppProxy: Boolean = false,
+    @SerialName("bypass_apps")
+    val bypassApps: Boolean = false,
+    @SerialName("proxy_apps")
+    val proxyApps: List<String> = emptyList()
 )
 
 @Serializable


### PR DESCRIPTION
## Related Issue

Relates to TrustTunnel/TrustTunnelFlutterClient#27
Partially addresses #24 (This implements application-based split tunneling for Android).

## Summary

This PR implements application-based split tunneling (per-app proxy) specifically for the Android platform. It allows defining an inclusion or exclusion list of Android package names to route through the VPN.

**Note: A corresponding PR implementing the UI for this feature will be opened in `TrustTunnelFlutterClient`.**

## Changes

- Added `perAppProxy` (bool), `bypassApps` (bool), and `proxyApps` (list) properties to the Kotlin `VpnServiceConfig` to receive configuration from the Flutter plugin.
- Modified `VpnService.kt` to apply `addAllowedApplication` and `addDisallowedApplication` rules to the Android `VpnService.Builder` during tunnel creation.

## Tests

- [ ] New or updated tests cover the changes
- [x] All existing tests pass (`make test`)
- [ ] Benchmarks updated (if performance-relevant)

## Checklist

- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-visible change)
- [x] No secrets or credentials committed