### PR TITLE
Fall into recovery when the initial connect fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The initial connect now falls into the session recovery loop instead of giving up after a fixed number of
+  attempts. Previously `trusttunnel_client` exited when its endpoint happened to be unavailable at startup, while
+  an already established session recovered normally. Errors that will not resolve on their own -- authentication,
+  certificate verification, location unavailable -- still end the session.
+
 ### Security
 
 ## [1.1.5] - 2026-09-02

--- a/core/test/test_vpn_manager_fsm_recovery.cpp
+++ b/core/test/test_vpn_manager_fsm_recovery.cpp
@@ -63,6 +63,8 @@ struct ConnectingVpnManagerTest : MockedTest {
     VpnError vpn_error{};
     bool timed_out = false;
 
+    VpnConnectRetryInfo retry_info = {.policy = VPN_CRP_SEVERAL_ATTEMPTS, .attempts_num = 1};
+
     void SetUp() override {
         MockedTest::SetUp();
 
@@ -85,7 +87,7 @@ struct ConnectingVpnManagerTest : MockedTest {
                                 .password = "1",
                                 .recovery = {.backoff_rate = 1},
                         },
-                .retry_info = {.policy = VPN_CRP_SEVERAL_ATTEMPTS, .attempts_num = 1},
+                .retry_info = retry_info,
         };
         vpn_connect(vpn, &parameters);
         vpn_event_loop_hijack(vpn->ev_loop.get());
@@ -222,6 +224,37 @@ struct ConnectedVpnManagerTest : public ConnectingVpnManagerTest {
         raise_client_event(vpn_client::EVENT_DISCONNECTED);
     }
 };
+
+struct RecoveringOnConnectVpnManagerTest : ConnectingVpnManagerTest {
+    void SetUp() override {
+        retry_info = {.policy = VPN_CRP_FALL_INTO_RECOVERY};
+        ConnectingVpnManagerTest::SetUp();
+    }
+};
+
+// Check that with `VPN_CRP_SEVERAL_ATTEMPTS` the session ends once the attempts
+// run out.
+TEST_F(ConnectingVpnManagerTest, SeveralAttemptsEndsTheSessionWhenTheyRunOut) {
+    raise_client_event(vpn_client::EVENT_DISCONNECTED);
+    ASSERT_TRUE(await_state_change(VPN_SS_DISCONNECTED));
+}
+
+// Check that with `VPN_CRP_FALL_INTO_RECOVERY` a failed initial connect enters
+// the recovery loop instead of ending the session.
+TEST_F(RecoveringOnConnectVpnManagerTest, FallIntoRecoveryKeepsTheSessionAlive) {
+    raise_client_event(vpn_client::EVENT_DISCONNECTED);
+    ASSERT_TRUE(await_state_change(VPN_SS_WAITING_RECOVERY));
+}
+
+// Check that a fatal error still ends the session under
+// `VPN_CRP_FALL_INTO_RECOVERY`: the fatal-error guard is evaluated before the
+// policy.
+TEST_F(RecoveringOnConnectVpnManagerTest, FallIntoRecoveryStillEndsOnAFatalError) {
+    VpnError error = {VPN_EC_AUTH_REQUIRED, "Authentication required"};
+    raise_client_event(vpn_client::EVENT_DISCONNECTED, &error);
+    ASSERT_TRUE(await_state_change(VPN_SS_DISCONNECTED));
+    ASSERT_EQ(VPN_EC_AUTH_REQUIRED, vpn_error.code);
+}
 
 TEST_F(ConnectedVpnManagerTest, BypassRequestsAreBypassedImmediately) {
     auto &c = test_mock::g_client;

--- a/trusttunnel/src/client.cpp
+++ b/trusttunnel/src/client.cpp
@@ -294,6 +294,7 @@ Error<TrustTunnelClient::ConnectResultError> TrustTunnelClient::connect_to_serve
                                     },
                             .anti_dpi = m_config.location.anti_dpi,
                     },
+            .retry_info = {.policy = VPN_CRP_FALL_INTO_RECOVERY},
     };
 
     {


### PR DESCRIPTION
## Related Issue

Closes #87

## Summary

`TrustTunnelClient::connect_to_server` leaves `VpnConnectParameters::retry_info`
zeroed, which selects `VPN_CRP_SEVERAL_ATTEMPTS`: five attempts, then
`VPN_SS_DISCONNECTED`. The console client stops itself on that state, so a client
started while its endpoint happens to be unavailable exits instead of waiting for
it. A session that was already established recovers normally -- only the initial
connect gives up.

The same call already asks for unbounded session recovery a few lines above
(`recovery.attempts = UINT32_MAX`), so the two halves disagreed with each other.
This selects `VPN_CRP_FALL_INTO_RECOVERY` so that a failed initial connect joins
the same recovery loop a dropped session uses.

Errors that will not resolve on their own still end the session: `is_fatal_error`
is evaluated before the policy in the transition table, so `VPN_EC_AUTH_REQUIRED`,
`VPN_EC_CERTIFICATE_VERIFICATION_FAILED` and `VPN_EC_LOCATION_UNAVAILABLE` behave
as before. An endpoint that is merely unreachable raises `VPN_EC_ERROR`, which is
not fatal -- `ping_failure_induces_location_unavailable` is set only by
`vpn_abandon_endpoint`.

Note that this also affects the platform adapters, which share
`TrustTunnelClient::connect`: a transient failure now shows as reconnecting
rather than as a terminal error, while genuine failures are still reported. If
you would rather keep the current behaviour there, I am happy to redo this as an
opt-in config option used only by the console client.

## Changes

- `trusttunnel/src/client.cpp`: select `VPN_CRP_FALL_INTO_RECOVERY` for the
  initial connect.
- `core/test/test_vpn_manager_fsm_recovery.cpp`: make the retry policy a fixture
  member so both policies can be exercised, and add three tests.
- `CHANGELOG.md`: entry under `[Unreleased]` / `Fixed`.

## Tests

- [x] New or updated tests cover the changes
- [x] All existing tests pass (`make test`)
- [ ] Benchmarks updated (if performance-relevant)

Added:

- `ConnectingVpnManagerTest.SeveralAttemptsEndsTheSessionWhenTheyRunOut` --
  the previous behaviour, kept so the contrast is visible.
- `RecoveringOnConnectVpnManagerTest.FallIntoRecoveryKeepsTheSessionAlive`
- `RecoveringOnConnectVpnManagerTest.FallIntoRecoveryStillEndsOnAFatalError`

`VPN_CRP_FALL_INTO_RECOVERY` had no caller and no coverage before this --
`git log -S VPN_CRP_FALL_INTO_RECOVERY` returns only the commit that opened the
sources.

Not covered: that `connect_to_server` passes this particular policy. There is no
test target for `trusttunnel/` beyond `test_persistent_ring_buffer.cpp`, so the
one-line change itself is verified by inspection rather than by a test.

Run locally on macOS (arm64, llvm@21, Conan 2.32): 233/233 C++ tests pass, Rust
workspace green.

## Checklist

- [ ] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (if user-visible change)
- [x] No secrets or credentials committed
